### PR TITLE
Optional redis cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Create new autoconfig object
 Where config is an optional (if not set, predefined values will be used) 
 configuration object with following properties:
 
+  * **disableCache** - Disable caching & redis (defaults to false)
   * **redis** - Redis configuration object (host, port, db)
   * **cacheExpire** - Cache expiration in seconds for checked keys (set 0 for eternity, defaults to 24h)
 

--- a/config.json
+++ b/config.json
@@ -1,4 +1,5 @@
 {
+    "disableCache": false,
     "redis": {
         "host": "localhost",
         "port": false,

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ module.exports.createIMAPSettingsDetector = createIMAPSettingsDetector;
 
 function createIMAPSettingsDetector(config){
     config = config || defaultConfig;
+    config.disableCache = config.disableCache || false;
     config.redis = config.redis || defaultConfig.redis;
 
     if(typeof config.cacheExpire == "undefined"){
@@ -18,7 +19,9 @@ function createIMAPSettingsDetector(config){
 
 function IMAPSettingsDetector(config){
     this.config = config;
-    this.redisClient = redis.createClient(config.redis.port, config.redis.host);
+    if (!this.config.disableCache) {
+      this.redisClient = redis.createClient(config.redis.port, config.redis.host);
+    }
 }
 
 IMAPSettingsDetector.prototype.detect = function(address, password, cached, callback){
@@ -31,7 +34,7 @@ IMAPSettingsDetector.prototype.detect = function(address, password, cached, call
 
     var cacheKey = "cache:autoconfig:"+sha1(address.split("@")[1] || "localhost");
 
-    if(cached){
+    if(!this.config.disableCache && cached){
         this.redisClient.multi().
             select(this.config.redis.db).
             hgetall(cacheKey).
@@ -68,7 +71,7 @@ IMAPSettingsDetector.prototype._checkSettings = function(address, password, cach
         }
 
         // overwrite cache only with a valid user information
-        if(settings.user){
+        if(!this.config.disableCache && settings.user){
             this.redisClient.multi().
                 select(this.config.redis.db).
                 hmset(cacheKey, settings).

--- a/index.js
+++ b/index.js
@@ -7,11 +7,14 @@ module.exports.createIMAPSettingsDetector = createIMAPSettingsDetector;
 
 function createIMAPSettingsDetector(config){
     config = config || defaultConfig;
-    config.disableCache = config.disableCache || false;
     config.redis = config.redis || defaultConfig.redis;
 
     if(typeof config.cacheExpire == "undefined"){
         config.cacheExpire = defaultConfig.cacheExpire;
+    }
+
+    if(typeof config.disableCache == "undefined"){
+        config.disableCache = defaultConfig.disableCache;
     }
 
     return new IMAPSettingsDetector(config);


### PR DESCRIPTION
Currently it's not possible to use this module without redis. This patch adds a new optional parameter `disableCache` which disables the redis cache. This parameter defaults to `false`, so updating current installations will not result in a changed behavior.
