### PR TITLE
Use best result instead of fastest result.

### DIFF
--- a/lib/detect.js
+++ b/lib/detect.js
@@ -11,32 +11,25 @@ function detectIMAPConnectionSettings(address, password, callback){
         password = undefined;
     }
 
-    var funcs = [
-            autoconfig.detectIMAPConnectionSettings.bind(autoconfig),
-            dnscheck.detectIMAPConnectionSettings.bind(dnscheck),
-            guess.detectIMAPConnectionSettings.bind(guess)
-        ],
-        ready = false,
-        waitingFor = funcs.length;
-
-    for(var i=0, len = funcs.length; i<len; i++){
-        funcs[i](address, password, function(err, data){
-            waitingFor--;
-
-            if(ready){
-                return;
-            }
-            
-            if(data){
-                ready = true;
-                return callback(null, data);
-            }
-
-            if(waitingFor == 0){
-                return callback(null, null);
-            }
-        });
-    }
+    autoconfig.detectIMAPConnectionSettings.bind(autoconfig)(address, password, function(err, data){
+        if(data){
+            return callback(null, data);
+        }else{
+            dnscheck.detectIMAPConnectionSettings.bind(dnscheck)(address, password, function(err, data){
+                if(data){
+                    return callback(null, data);
+                }else{
+                    guess.detectIMAPConnectionSettings.bind(guess)(address, password, function(err, data){
+                        if(data){
+                            return callback(null, data);
+                        }else{
+                          return callback(null, null);
+                        }
+                    });
+                }
+            });
+        }
+    });
 }
 
 function checkLoginData(port, host, options, callback){


### PR DESCRIPTION
In our tests, we almost always got the response from `guess.detectIMAPConnectionSettings` as this was way faster than `autoconfig.detectIMAPConnectionSettings` checking all the urls.

For example checking a gmx.de mail returns the following results with the old code (from guess):

```
{ host: 'imap.gmx.de', port: 143, secure: false }
```

Result with the new code (from autoconfig):

```
{ host: 'imap.gmx.net', port: '993', secure: true }
```

While the result from guess is faster, the result from autoconfig is the correct one.
